### PR TITLE
Update to VS for Mac 17.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib/Eto"]
-	path = lib/Eto
-	url = https://github.com/picoe/Eto.git

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <VSVersion Condition="$(VSVersion) == ''">2022</VSVersion>
 
     <BasePath>$(MSBuildThisFileDirectory)</BasePath>
     <BasePath>$([System.IO.Path]::GetFullPath($(BasePath)))</BasePath>
@@ -22,9 +23,9 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <DevVersion>2.7.0</DevVersion>
+    <DevVersion>2.7.1</DevVersion>
 
-    <Version Condition="$(Version) == ''">2.7.0.0</Version>
+    <Version Condition="$(Version) == ''">2.7.1.0</Version>
 
     <InformationalVersion Condition="$(SetVersion) != ''">$(SetVersion)</InformationalVersion>
     <!-- set version from tag -->

--- a/lib/Eto.Common.props
+++ b/lib/Eto.Common.props
@@ -1,9 +1,0 @@
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<PropertyGroup Condition="$(MSBuildProjectFile) == 'Eto.XamMac2.csproj'">
-    <TargetFramework>net6.0</TargetFramework>
-    <NoWarn>CA1416</NoWarn>
-    <UseXamarinMac>False</UseXamarinMac>
-    <OverrideTargetFrameworks>True</OverrideTargetFrameworks>
-    <DefineConstants>MACOS_NET;VSMAC</DefineConstants>
-  </PropertyGroup>
-</Project>

--- a/lib/Eto.Common.targets
+++ b/lib/Eto.Common.targets
@@ -1,5 +1,0 @@
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Condition="$(MSBuildProjectFile) == 'Eto.XamMac2.csproj'">
-    <PackageReference Include="Microsoft.VisualStudioMac.Sdk" Version="17.0.0" ExcludeAssets="runtime"/>
-  </ItemGroup>
-</Project>

--- a/src/Eto.Designer/Eto.Designer.csproj
+++ b/src/Eto.Designer/Eto.Designer.csproj
@@ -4,9 +4,9 @@
     <DefineConstants>Roslyn;RoslynCS;RoslynVB</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Eto.Forms" Version="2.7.0" PrivateAssets="all" ExcludeAssets="runtime" />
-    <PackageReference Include="Eto.Serialization.Json" Version="2.7.0" />
-    <PackageReference Include="Eto.Serialization.Xaml" Version="2.7.0" />
+    <PackageReference Include="Eto.Forms" Version="2.7.1" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="Eto.Serialization.Json" Version="2.7.1" />
+    <PackageReference Include="Eto.Serialization.Xaml" Version="2.7.1" />
   </ItemGroup>
   <ItemGroup>
     <!-- <PackageReference Include="System.CodeDom" Version="6.0.0" Condtion="$(TargetFramework) == 'net472'" />

--- a/src/Eto.DevExtension.Shared/Eto.DevExtension.Shared.csproj
+++ b/src/Eto.DevExtension.Shared/Eto.DevExtension.Shared.csproj
@@ -4,8 +4,8 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Eto.Designer\Eto.Designer.csproj" />
-    <PackageReference Include="Eto.Forms" Version="2.7.0" PrivateAssets="all" ExcludeAssets="runtime" />
-    <!-- <PackageReference Include="Eto.Forms" Version="2.7.0" /> -->
+    <PackageReference Include="Eto.Forms" Version="2.7.1" PrivateAssets="all" ExcludeAssets="runtime" />
+    <!-- <PackageReference Include="Eto.Forms" Version="2.7.1" /> -->
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/Eto.DevExtension.VisualStudio.Mac/EnhancedFile.cs
+++ b/src/Eto.DevExtension.VisualStudio.Mac/EnhancedFile.cs
@@ -16,192 +16,192 @@ using System.Threading.Tasks;
 
 namespace Eto.DevExtension.VisualStudio.Mac
 {
-    public class EnhancedFile : FileDescriptionTemplate
-    {
-        readonly ReplacementFile inner;
+	public class EnhancedFile : FileDescriptionTemplate
+	{
+		readonly ReplacementFile inner;
 
-        // why? because TextFileDescriptionTemplate doesn't give us a way to access the generated ProjectFile
-        class ReplacementFile : TextFileDescriptionTemplate
-        {
-            public EnhancedFile Outer { get; set; }
+		// why? because TextFileDescriptionTemplate doesn't give us a way to access the generated ProjectFile
+		class ReplacementFile : TextFileDescriptionTemplate
+		{
+			public EnhancedFile Outer { get; set; }
 
-            IStringTagModel tagModel;
+			IStringTagModel tagModel;
 
-            TagModel GetTagModel(SolutionFolderItem policyParent, Project project, string language, string identifier, string fileName)
-            {
-                var model = new TagModel();
-                var projectModel = ProjectTagModel ?? Outer.ProjectTagModel;
-                if (projectModel != null)
-                    model.InnerModels = new[] { projectModel };
-                ModifyTags(policyParent, project, language, identifier, fileName, ref model.OverrideTags);
-                return model;
-            }
+			TagModel GetTagModel(SolutionFolderItem policyParent, Project project, string language, string identifier, string fileName)
+			{
+				var model = new TagModel();
+				var projectModel = ProjectTagModel ?? Outer.ProjectTagModel;
+				if (projectModel != null)
+					model.InnerModels = new[] { projectModel };
+				ModifyTags(policyParent, project, language, identifier, fileName, ref model.OverrideTags);
+				return model;
+			}
 
 #if VS2019
-			public override async Task<Stream> CreateFileContentAsync (SolutionFolderItem policyParent, Project project, string language, string fileName, string identifier)
+			public override async Task<Stream> CreateFileContentAsync(SolutionFolderItem policyParent, Project project, string language, string fileName, string identifier)
 			{
 				if (Outer.FormatCode)
 				{
 					return await base.CreateFileContentAsync(policyParent, project, language, fileName, identifier);
 				}
 
-				var model = GetTagModel (policyParent, project, language, identifier, fileName);
-				string text = CreateContent (project, model.OverrideTags, language);
+				var model = GetTagModel(policyParent, project, language, identifier, fileName);
+				string text = CreateContent(project, model.OverrideTags, language);
 
-				text = ProcessContent (text, model);
-				var memoryStream = new MemoryStream ();
-				byte[] preamble = Encoding.UTF8.GetPreamble ();
-				await memoryStream.WriteAsync (preamble, 0, preamble.Length);
-				if (AddStandardHeader) {
-					string header = StandardHeaderService.GetHeader (policyParent, fileName, true);
-					byte[] bytes = Encoding.UTF8.GetBytes (header);
-					await memoryStream.WriteAsync (bytes, 0, bytes.Length);
+				text = ProcessContent(text, model);
+				var memoryStream = new MemoryStream();
+				byte[] preamble = Encoding.UTF8.GetPreamble();
+				await memoryStream.WriteAsync(preamble, 0, preamble.Length);
+				if (AddStandardHeader)
+				{
+					string header = StandardHeaderService.GetHeader(policyParent, fileName, true);
+					byte[] bytes = Encoding.UTF8.GetBytes(header);
+					await memoryStream.WriteAsync(bytes, 0, bytes.Length);
 				}
 
-#if VS2019
 				var textDocument = TextEditorFactory.CreateNewDocument();
-#else
-				var textDocument = await TextEditorFactory.CreateNewDocumentAsync();
-#endif
+                
 				//var textDocument = new TextDocument ();
 				textDocument.Text = text;
-				var textStylePolicy = (policyParent == null) ? PolicyService.GetDefaultPolicy<TextStylePolicy> ("text/plain") : policyParent.Policies.Get<TextStylePolicy> ("text/plain");
-				string eolMarker = TextStylePolicy.GetEolMarker (textStylePolicy.EolMarker);
-				byte[] eol = Encoding.UTF8.GetBytes (eolMarker);
-				string indent = (!textStylePolicy.TabsToSpaces) ? null : new string (' ', textStylePolicy.TabWidth);
-				foreach (var current in textDocument.GetLines()) {
-					string line = textDocument.GetTextAt (current.Offset, current.Length);
-					if (indent != null) {
-						line = line.Replace ("	", indent);
+				var textStylePolicy = (policyParent == null) ? PolicyService.GetDefaultPolicy<TextStylePolicy>("text/plain") : policyParent.Policies.Get<TextStylePolicy>("text/plain");
+				string eolMarker = TextStylePolicy.GetEolMarker(textStylePolicy.EolMarker);
+				byte[] eol = Encoding.UTF8.GetBytes(eolMarker);
+				string indent = (!textStylePolicy.TabsToSpaces) ? null : new string(' ', textStylePolicy.TabWidth);
+				foreach (var current in textDocument.GetLines())
+				{
+					string line = textDocument.GetTextAt(current.Offset, current.Length);
+					if (indent != null)
+					{
+						line = line.Replace("	", indent);
 					}
-					byte[] bytes = Encoding.UTF8.GetBytes (line);
-					await memoryStream.WriteAsync (bytes, 0, bytes.Length);
-					await memoryStream.WriteAsync (eol, 0, eol.Length);
+					byte[] bytes = Encoding.UTF8.GetBytes(line);
+					await memoryStream.WriteAsync(bytes, 0, bytes.Length);
+					await memoryStream.WriteAsync(eol, 0, eol.Length);
 				}
 				memoryStream.Position = 0;
-				return memoryStream;				
+				return memoryStream;
 			}
 #endif
 
 			protected override string ProcessContent(string content, IStringTagModel tags)
-            {
-                tags = new TagModel { InnerModels = new[] { tags, Outer.ProjectTagModel }, File = Outer };
-                tagModel = tags;
-                return base.ProcessContent(content, tags);
-            }
+			{
+				tags = new TagModel { InnerModels = new[] { tags, Outer.ProjectTagModel }, File = Outer };
+				tagModel = tags;
+				return base.ProcessContent(content, tags);
+			}
 
-            public string ProcessContent(string content)
-            {
-                if (tagModel == null)
-                    throw new InvalidOperationException("Cannot process content with no tag model defined. Only use this after processing file content");
-                return base.ProcessContent(content, tagModel);
-            }
-        }
+			public string ProcessContent(string content)
+			{
+				if (tagModel == null)
+					throw new InvalidOperationException("Cannot process content with no tag model defined. Only use this after processing file content");
+				return base.ProcessContent(content, tagModel);
+			}
+		}
 
-        public EnhancedFile()
-        {
-            inner = new ReplacementFile { Outer = this };
-        }
+		public EnhancedFile()
+		{
+			inner = new ReplacementFile { Outer = this };
+		}
 
-        public Dictionary<string, Replacement> Replacements { get; set; }
+		public Dictionary<string, Replacement> Replacements { get; set; }
 
-        public string ResourceId { get; set; }
+		public string ResourceId { get; set; }
 
-        public bool FormatCode { get; set; } = true;
+		public bool FormatCode { get; set; } = true;
 
-        public class Replacement
-        {
-            public string Name { get; set; }
+		public class Replacement
+		{
+			public string Name { get; set; }
 
-            public string Value { get; set; }
+			public string Value { get; set; }
 
-            public Replacement(XmlElement element)
-            {
-                Name = element.GetAttribute("name");
-                Value = element.GetAttribute("value");
-            }
-        }
+			public Replacement(XmlElement element)
+			{
+				Name = element.GetAttribute("name");
+				Value = element.GetAttribute("value");
+			}
+		}
 
-        public override void Load(System.Xml.XmlElement filenode, md.Core.FilePath baseDirectory)
-        {
-            var formatCodeString = filenode.GetAttribute("FormatCode");
-            if (!string.IsNullOrEmpty(formatCodeString))
-                FormatCode = bool.Parse(formatCodeString);
-            ResourceId = filenode.GetAttribute("ResourceId");
-            var replacements = filenode.SelectNodes("Replacements/Replacement");
-            Replacements = replacements.OfType<XmlElement>().Select(r => new Replacement(r)).ToDictionary(r => r.Name, StringComparer.OrdinalIgnoreCase);
-            inner.Load(filenode, baseDirectory);
-        }
+		public override void Load(System.Xml.XmlElement filenode, md.Core.FilePath baseDirectory)
+		{
+			var formatCodeString = filenode.GetAttribute("FormatCode");
+			if (!string.IsNullOrEmpty(formatCodeString))
+				FormatCode = bool.Parse(formatCodeString);
+			ResourceId = filenode.GetAttribute("ResourceId");
+			var replacements = filenode.SelectNodes("Replacements/Replacement");
+			Replacements = replacements.OfType<XmlElement>().Select(r => new Replacement(r)).ToDictionary(r => r.Name, StringComparer.OrdinalIgnoreCase);
+			inner.Load(filenode, baseDirectory);
+		}
 
-        class TagModel : IStringTagModel
-        {
-            public IStringTagModel[] InnerModels { get; set; }
+		class TagModel : IStringTagModel
+		{
+			public IStringTagModel[] InnerModels { get; set; }
 
-            public Dictionary<string, string> OverrideTags = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+			public Dictionary<string, string> OverrideTags = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-            public EnhancedFile File { get; set; }
+			public EnhancedFile File { get; set; }
 
-            public object GetValue(string name)
-            {
-                Replacement parameter;
-                if (File != null && File.Replacements != null && File.Replacements.TryGetValue(name, out parameter))
-                    return parameter.Value;
+			public object GetValue(string name)
+			{
+				Replacement parameter;
+				if (File != null && File.Replacements != null && File.Replacements.TryGetValue(name, out parameter))
+					return parameter.Value;
 
-                string overrideValue;
-                if (OverrideTags != null && OverrideTags.TryGetValue(name, out overrideValue))
-                    return overrideValue;
+				string overrideValue;
+				if (OverrideTags != null && OverrideTags.TryGetValue(name, out overrideValue))
+					return overrideValue;
 
-                if (InnerModels != null)
-                {
-                    foreach (var inner in InnerModels)
-                    {
-                        var value = inner.GetValue(name);
-                        if (value != null)
-                            return value;
-                    }
-                }
-                return null;
-            }
-        }
+				if (InnerModels != null)
+				{
+					foreach (var inner in InnerModels)
+					{
+						var value = inner.GetValue(name);
+						if (value != null)
+							return value;
+					}
+				}
+				return null;
+			}
+		}
 
-        public override bool SupportsProject(Project project, string projectPath)
-        {
-            return inner.SupportsProject(project, projectPath);
-        }
+		public override bool SupportsProject(Project project, string projectPath)
+		{
+			return inner.SupportsProject(project, projectPath);
+		}
 
-        public override bool IsValidName(string name, string language)
-        {
-            return inner.IsValidName(name, language);
-        }
+		public override bool IsValidName(string name, string language)
+		{
+			return inner.IsValidName(name, language);
+		}
 
 		public override async Task<bool> AddToProjectAsync(SolutionFolderItem policyParent, Project project, string language, string directory, string name)
 		{
-            var file = await inner.AddFileToProjectAsync(policyParent, project, language, directory, name);
-            if (file == null)
-                return false;
+			var file = await inner.AddFileToProjectAsync(policyParent, project, language, directory, name);
+			if (file == null)
+				return false;
 
-            if (!string.IsNullOrEmpty(ResourceId))
-                file.ResourceId = inner.ProcessContent(ResourceId);
+			if (!string.IsNullOrEmpty(ResourceId))
+				file.ResourceId = inner.ProcessContent(ResourceId);
 
-            /* TODO: Add required packages here?
+			/* TODO: Add required packages here?
 			var dnproject = project as DotNetProject;
 			if (dnproject != null)
 			{
 			}
 			*/
 
-            return true;
-        }
+			return true;
+		}
 
-        public override void Show()
-        {
-            inner.Show();
-        }
+		public override void Show()
+		{
+			inner.Show();
+		}
 
-        public override string Name
-        {
-            get { return inner.Name; }
-        }
-    }
+		public override string Name
+		{
+			get { return inner.Name; }
+		}
+	}
 }
 

--- a/src/Eto.DevExtension.VisualStudio.Mac/Eto.DevExtension.VisualStudio.Mac.csproj
+++ b/src/Eto.DevExtension.VisualStudio.Mac/Eto.DevExtension.VisualStudio.Mac.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VSVersion Condition="$(VSVersion) == ''">2022</VSVersion>
     <DefineConstants>$(DefineConstants);MAC;VS$(VSVersion)</DefineConstants>
-    <NoWarn>MSB3245</NoWarn>
+    <NoWarn>MSB3245;MSB3270</NoWarn>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
     <BaseOutputPath>$(BaseOutputPath)$(VSVersion)\</BaseOutputPath>
@@ -32,25 +31,24 @@
       <IncludeAssets>compile;build;native;contentfiles;analyzers;buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
-    <PackageReference Include="Eto.Forms" Version="2.7.0" GeneratePathProperty="true" />
-    <PackageReference Include="Eto.Platform.XamMac2" Version="2.7.0" />
+    <PackageReference Include="Eto.Platform.XamMac2" Version="2.7.1" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition="$(VSVersion) == '2022'">
     <TargetFramework>net6.0-macos</TargetFramework>
-    <MonoDevelopVersion>17.0</MonoDevelopVersion>
+    <MonoDevelopVersion>17.3</MonoDevelopVersion>
   </PropertyGroup>
   <ItemGroup Condition="$(VSVersion) == '2022'">
     <PackageReference Include="Microsoft.VisualStudioMac.Sdk" Version="17.0.0" ExcludeAssets="runtime"/>
-    <!-- <PackageReference Include="Eto.Platform.macOS" Version="2.7.0" GeneratePathProperty="true" /> -->
-    <ProjectReference Include="$(BasePath)lib\Eto\src\Eto\Eto.csproj" /> 
-    <ProjectReference Include="$(BasePath)lib\Eto\src\Eto.Mac\Eto.XamMac2.csproj" /> 
+    <PackageReference Include="Eto.Platform.macOS" Version="2.7.1" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="FSharp.Core" Version="6.0.4" ExcludeAssets="runtime"  />
-    <PackageReference Include="Eto.Forms.Templates" Version="2.7.0" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Eto.Forms" Version="2.7.1" GeneratePathProperty="true" />
+    <PackageReference Include="Eto.Forms.Templates" Version="2.7.1" GeneratePathProperty="true" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <AddinReference Include="MonoDevelop.Xml" />
@@ -95,6 +93,6 @@
   </Target>
 
   <Target Name="CopyEtoXml" AfterTargets="Build">
-    <Copy SourceFiles="$(PkgEto_Forms)\lib\netstandard2.0\Eto.xml" DestinationFolder="$(OutDir)" Condition="$(VSVersion) == '2019'" />
+    <Copy SourceFiles="$(PkgEto_Forms)\lib\netstandard2.0\Eto.xml" DestinationFolder="$(OutDir)" />
   </Target>
 </Project>

--- a/src/Eto.DevExtension.VisualStudio.Mac/Extensions.cs
+++ b/src/Eto.DevExtension.VisualStudio.Mac/Extensions.cs
@@ -5,10 +5,10 @@ namespace Eto.DevExtension.VisualStudio.Mac
 	public static class Extensions
 	{
 #if VS2022
-		// public static Color ToEto(this MonoDevelop.Ide.Gui.Styles.IdeColor color)
-		// {
-		// 	return new Color((AppKit.NSColor)color, (float)color.Red, (float)color.Green, (float)color.Blue, (float)color.Alpha);
-		// }
+		public static Color ToEto(this MonoDevelop.Ide.Gui.Styles.IdeColor color)
+		{
+			return new Color((AppKit.NSColor)color, (float)color.Red, (float)color.Green, (float)color.Blue, (float)color.Alpha);
+		}
 #endif
 		public static Color ToEto(this Xwt.Drawing.Color color)
 		{

--- a/src/Eto.DevExtension.VisualStudio.Mac/Properties/AddinInfo.cs
+++ b/src/Eto.DevExtension.VisualStudio.Mac/Properties/AddinInfo.cs
@@ -5,7 +5,7 @@ using Mono.Addins.Description;
 [assembly:Addin(
 	"Mac", 
 	Namespace = "Eto.DevExtension.VisualStudio",
-	Version = "2.7.0.0"
+	Version = "2.7.1.0"
 )]
 
 [assembly:AddinName("Eto.Forms VS Extension")]

--- a/src/Eto.DevExtension.VisualStudio.Windows/2019/source.extension.vsixmanifest
+++ b/src/Eto.DevExtension.VisualStudio.Windows/2019/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Eto.DevExtension.VisualStudio" Version="2.7.0.0" Language="en-US" Publisher="Curtis Wensley" />
+        <Identity Id="Eto.DevExtension.VisualStudio" Version="2.7.1.0" Language="en-US" Publisher="Curtis Wensley" />
         <DisplayName>Eto.Forms Visual Studio Addin</DisplayName>
         <Description xml:space="preserve">Eto.Forms Support for Visual Studio.  Eto.Forms is a cross platform GUI framework for desktop and mobile applications in .NET that can target Wpf, WinForms, Direct2D, MonoMac, Xamarin.Mac, Gtk2, and Gtk3 with a single codebase.</Description>
         <MoreInfo>https://github.com/picoe/Eto</MoreInfo>

--- a/src/Eto.DevExtension.VisualStudio.Windows/2022/source.extension.vsixmanifest
+++ b/src/Eto.DevExtension.VisualStudio.Windows/2022/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
     xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011"
     xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Eto.DevExtension.VisualStudio" Version="2.7.0.0" Language="en-US" Publisher="Curtis Wensley" />
+        <Identity Id="Eto.DevExtension.VisualStudio" Version="2.7.1.0" Language="en-US" Publisher="Curtis Wensley" />
         <DisplayName>Eto.Forms Visual Studio Addin</DisplayName>
         <Description xml:space="preserve">Eto.Forms Support for Visual Studio.  Eto.Forms is a cross platform GUI framework for desktop and mobile applications in .NET that can target Wpf, WinForms, Direct2D, MonoMac, Xamarin.Mac, Gtk2, and Gtk3 with a single codebase.</Description>
         <MoreInfo>https://github.com/picoe/Eto</MoreInfo>

--- a/src/Eto.DevExtension.VisualStudio.Windows/Eto.DevExtension.VisualStudio.Windows.csproj
+++ b/src/Eto.DevExtension.VisualStudio.Windows/Eto.DevExtension.VisualStudio.Windows.csproj
@@ -5,7 +5,6 @@
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
-    <VSVersion Condition="$(VSVersion) == ''">2022</VSVersion>
   </PropertyGroup>
   <!-- This gives a warning when building.. but it doesn't work without it. -->
   <Import Project="..\..\Directory.Build.props" />
@@ -217,11 +216,11 @@
     </COMReference> -->
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Eto.Forms" GeneratePathProperty="True" Version="2.7.0" />
-    <PackageReference Include="Eto.Platform.Wpf" Version="2.7.0" />
-    <PackageReference Include="Eto.Serialization.Json" Version="2.7.0" />
-    <PackageReference Include="Eto.Serialization.Xaml" Version="2.7.0" />
-    <PackageReference Include="Eto.Forms.Templates" Version="2.7.0" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Eto.Forms" GeneratePathProperty="True" Version="2.7.1" />
+    <PackageReference Include="Eto.Platform.Wpf" Version="2.7.1" />
+    <PackageReference Include="Eto.Serialization.Json" Version="2.7.1" />
+    <PackageReference Include="Eto.Serialization.Xaml" Version="2.7.1" />
+    <PackageReference Include="Eto.Forms.Templates" Version="2.7.1" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="FSharp.Core" Version="5.0.1" />
     <PackageReference Include="Portable.Xaml" Version="0.26.0" />
     <PackageReference Include="Extended.Wpf.Toolkit" Version="3.6.0" />

--- a/src/Eto.DevExtension.VisualStudio.Windows/Eto.DevExtension.VisualStudio.Windows.csproj
+++ b/src/Eto.DevExtension.VisualStudio.Windows/Eto.DevExtension.VisualStudio.Windows.csproj
@@ -243,7 +243,7 @@
         <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.32112.339" ExcludeAssets="runtime">
           <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5232">
+        <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.3.2093">
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Eto.DevExtension.VisualStudio.Windows/Properties/AssemblyInfo.cs
+++ b/src/Eto.DevExtension.VisualStudio.Windows/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Eto.VisualStudio")]
 [assembly: AssemblyDescription("")]
 
-[assembly: AssemblyVersion("2.7.0.0")]
+[assembly: AssemblyVersion("2.7.1.0")]
 
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -21,6 +21,6 @@ using System.Runtime.InteropServices;
 
 [assembly: ProvideCodeBase(
 	AssemblyName = "Eto.DevExtension.VisualStudio.Windows",
-	Version = "2.7.0.0",
+	Version = "2.7.1.0",
 	CodeBase = "$PackageFolder$\\Eto.DevExtension.VisualStudio.Windows.dll")]
 

--- a/src/Eto.DevExtension.VisualStudio.Windows/Templates/App-CSharp/App.vstemplate
+++ b/src/Eto.DevExtension.VisualStudio.Windows/Templates/App-CSharp/App.vstemplate
@@ -35,7 +35,7 @@
 		</CustomParameters>
 	</TemplateContent>
 	<WizardExtension>
-		<Assembly>Eto.DevExtension.VisualStudio.Windows, Version=2.7.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
+		<Assembly>Eto.DevExtension.VisualStudio.Windows, Version=2.7.1.0, Culture=neutral, PublicKeyToken=null</Assembly>
 		<FullClassName>Eto.DevExtension.VisualStudio.Windows.Wizards.ProjectWizard</FullClassName>
 	</WizardExtension>
 	<WizardExtension>

--- a/src/Eto.DevExtension.VisualStudio.Windows/Templates/App-FSharp/App.vstemplate
+++ b/src/Eto.DevExtension.VisualStudio.Windows/Templates/App-FSharp/App.vstemplate
@@ -35,7 +35,7 @@
 		</CustomParameters>
 	</TemplateContent>
 	<WizardExtension>
-		<Assembly>Eto.DevExtension.VisualStudio.Windows, Version=2.7.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
+		<Assembly>Eto.DevExtension.VisualStudio.Windows, Version=2.7.1.0, Culture=neutral, PublicKeyToken=null</Assembly>
 		<FullClassName>Eto.DevExtension.VisualStudio.Windows.Wizards.ProjectWizard</FullClassName>
 	</WizardExtension>
 	<WizardExtension>

--- a/src/Eto.DevExtension.VisualStudio.Windows/Templates/App-VisualBasic/App.vstemplate
+++ b/src/Eto.DevExtension.VisualStudio.Windows/Templates/App-VisualBasic/App.vstemplate
@@ -35,7 +35,7 @@
 		</CustomParameters>
 	</TemplateContent>
 	<WizardExtension>
-		<Assembly>Eto.DevExtension.VisualStudio.Windows, Version=2.7.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
+		<Assembly>Eto.DevExtension.VisualStudio.Windows, Version=2.7.1.0, Culture=neutral, PublicKeyToken=null</Assembly>
 		<FullClassName>Eto.DevExtension.VisualStudio.Windows.Wizards.ProjectWizard</FullClassName>
 	</WizardExtension>
 	<WizardExtension>

--- a/src/Eto.DevExtension.VisualStudio.Windows/Templates/File-CSharp/File.vstemplate
+++ b/src/Eto.DevExtension.VisualStudio.Windows/Templates/File-CSharp/File.vstemplate
@@ -24,7 +24,7 @@
 		</CustomParameters>
 	</TemplateContent>
 	<WizardExtension>
-		<Assembly>Eto.DevExtension.VisualStudio.Windows, Version=2.7.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
+		<Assembly>Eto.DevExtension.VisualStudio.Windows, Version=2.7.1.0, Culture=neutral, PublicKeyToken=null</Assembly>
 		<FullClassName>Eto.DevExtension.VisualStudio.Windows.Wizards.ProjectWizard</FullClassName>
 	</WizardExtension>
 	<WizardExtension>

--- a/src/Eto.DevExtension.VisualStudio.Windows/Templates/File-FSharp/File.vstemplate
+++ b/src/Eto.DevExtension.VisualStudio.Windows/Templates/File-FSharp/File.vstemplate
@@ -24,7 +24,7 @@
 		</CustomParameters>
 	</TemplateContent>
 	<WizardExtension>
-		<Assembly>Eto.DevExtension.VisualStudio.Windows, Version=2.7.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
+		<Assembly>Eto.DevExtension.VisualStudio.Windows, Version=2.7.1.0, Culture=neutral, PublicKeyToken=null</Assembly>
 		<FullClassName>Eto.DevExtension.VisualStudio.Windows.Wizards.ProjectWizard</FullClassName>
 	</WizardExtension>
 	<WizardExtension>

--- a/src/Eto.DevExtension.VisualStudio.Windows/Templates/File-VisualBasic/File.vstemplate
+++ b/src/Eto.DevExtension.VisualStudio.Windows/Templates/File-VisualBasic/File.vstemplate
@@ -24,7 +24,7 @@
 		</CustomParameters>
 	</TemplateContent>
 	<WizardExtension>
-		<Assembly>Eto.DevExtension.VisualStudio.Windows, Version=2.7.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
+		<Assembly>Eto.DevExtension.VisualStudio.Windows, Version=2.7.1.0, Culture=neutral, PublicKeyToken=null</Assembly>
 		<FullClassName>Eto.DevExtension.VisualStudio.Windows.Wizards.ProjectWizard</FullClassName>
 	</WizardExtension>
 	<WizardExtension>


### PR DESCRIPTION
- No longer need to use Eto as a submodule as VS for Mac 2022 v17.3 is now using the latest macOS sdks (finally).
- Update to Eto 2.7.1